### PR TITLE
feat: add mathjax plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
 - [vuepress-plugin-autonav](https://github.com/webmasterish/vuepress-plugin-autonav) - Auto nav links plugin for VuePress
 - [vuepress-plugin-feed](https://github.com/webmasterish/vuepress-plugin-feed) - RSS, Atom, and JSON feeds generator plugin for VuePress
 - [vuepress-plugin-permalink-pinyin](https://github.com/viko16/vuepress-plugin-permalink-pinyin) - A VuePress plugin which convert Chinese title to transliterate permalink
+- [vuepress-plugin-mathjax](https://github.com/Shigma/vuepress-plugin-mathjax) - A VuePress plugin which supports TeX syntax in markdown files
 
 # Themes
 


### PR DESCRIPTION
It seems that vuepress-plugin-latex is no longer maintained, so I wrote a mathjax plugin.