### PR TITLE
Ghost URL Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ### External Resources
 
-- [Working with Ghost and VuePress](https://ghost.org/docs/api/v2/vuepress/)
+- [Working with Ghost and VuePress](https://ghost.org/docs/api/vuepress/)
 
 ### Tutorials
 


### PR DESCRIPTION
Our documentation uses a specific URL pattern to ensure people are directed to the latest version of our docs, hence the removal of `v2/` in this case. Thanks!